### PR TITLE
Use mirrorlist.c.o instead of mirror.c.o

### DIFF
--- a/CentOS-Gluster-4.1.repo
+++ b/CentOS-Gluster-4.1.repo
@@ -5,7 +5,8 @@
 
 [centos-gluster41]
 name=CentOS-$releasever - Gluster 4.1 (Long Term Maintanance)
-baseurl=http://mirror.centos.org/$contentdir/$releasever/storage/$basearch/gluster-4.1/
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=storage-gluster-4.1
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/storage/$basearch/gluster-4.1/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Storage

--- a/centos-release-gluster41.spec
+++ b/centos-release-gluster41.spec
@@ -1,7 +1,7 @@
 Summary: Gluster 4.1 (Long Term Stable) packages from the CentOS Storage SIG repository
 Name: centos-release-gluster41
 Version: 1.0
-Release: 3%{?dist}
+Release: 4%{?dist}
 License: GPLv2
 URL: http://wiki.centos.org/SpecialInterestGroup/Storage
 Source0: CentOS-Gluster-4.1.repo
@@ -39,6 +39,9 @@ sed -i 's/i\$contentdir/centos/g' %{buildroot}%{_sysconfdir}/yum.repos.d/CentOS-
 %config(noreplace) %{_sysconfdir}/yum.repos.d/CentOS-Gluster-4.1.repo
 
 %changelog
+* Mon Dec 10 2018 Anssi Johansson <avij@centosproject.org> - 1.0-4
+- Use mirrorlist.c.o instead of mirror.c.o
+
 * Tue Jul 31 2018 Niels de Vos <ndevos@redhat.com> - 1.0-3
 - Correct handling of altarch repositories on CentOS-6
 


### PR DESCRIPTION
You can now use mirrorlist.centos.org instead of mirror.centos.org for the content. For example, see these URLs:

http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=storage-gluster-4.1
http://mirrorlist.centos.org/?release=7&arch=aarch64&repo=storage-gluster-4.1
http://mirrorlist.centos.org/?release=6&arch=x86_64&repo=storage-gluster-5
http://mirrorlist.centos.org/?release=7&arch=ppc64le&repo=storage-gluster-5

Any new SIG repositories will automatically become available on mirrorlist.centos.org once the repository hits mirror.centos.org.

Most of mirror.centos.org hosts are also used for seeding the 600+ external mirrors we have. By directing some of their download traffic to external mirrors we can offer faster sync speeds for those external mirrors, and for people downloading individual rpms from mirror.centos.org. Second, most of those external mirrors offer faster download speeds to end users than what could be achieved by downloading from mirror.centos.org, so the users will benefit from this change as well. Finally, because there are much more external mirrors than mirror.centos.org nodes, it is likely that your bits will need to travel a shorter path, conserving bandwidth globally.